### PR TITLE
Update README: Recommend `duolingo-desktop-bin` over `duolingo-deskto…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,55 +2,57 @@
 
 # About
 
-This is an **unofficial** Linux desktop client for Duolingo, that works as a wrapper around the official web app.
+This is an **unofficial** Linux desktop client for Duolingo, which works as a wrapper around the official web app.
 
 # Installation
 
-[![Get it from the AUR](https://raw.githubusercontent.com/hmlendea/readme-assets/master/install_from_aur.png)](https://aur.archlinux.org/packages/duolingo-desktop-git/) [![Get it from FlatHub](https://raw.githubusercontent.com/hmlendea/readme-assets/master/badges/stores/flathub.png)](https://flathub.org/apps/details/ro.go.hmlendea.DL-Desktop) [![Get it from the Snap Store](https://raw.githubusercontent.com/snapcore/snap-store-badges/master/EN/%5BEN%5D-snap-store-white.png)](https://snapcraft.io/duolingo-desktop)
+[![Get it from the AUR](https://raw.githubusercontent.com/hmlendea/readme-assets/master/install_from_aur.png)](https://aur.archlinux.org/packages/duolingo-desktop-bin/) [![Get it from FlatHub](https://raw.githubusercontent.com/hmlendea/readme-assets/master/badges/stores/flathub.png)](https://flathub.org/apps/details/ro.go.hmlendea.DL-Desktop) [![Get it from the Snap Store](https://raw.githubusercontent.com/snapcore/snap-store-badges/master/EN/%5BEN%5D-snap-store-white.png)](https://snapcraft.io/duolingo-desktop)
 
-**Note**: _Only the FlatHub version is supported by this repository. The rest are community-supported and issues encountered while installing/using them should be reported on their respective pages._
+**Note**: _Only the FlatHub version is officially supported by this repository. The AUR and Snap versions are community-maintained. Please report any issues with these versions on their respective pages._
 
 ## Using a package manager
 
-On Arch Linux, the package is available on the AUR ([duolingo-desktop-git](https://aur.archlinux.org/packages/duolingo-desktop-git/)).
+On Arch Linux, the package is available on the AUR: [duolingo-desktop-bin](https://aur.archlinux.org/packages/duolingo-desktop-bin/).  
+Please note that the package `duolingo-desktop-git` has not been updated since 2020. Therefore, we recommend using `duolingo-desktop-bin` for installing Duolingo on Arch.
 
-For other distributions, you will have to check if someone included this package into the package manager's repository.
+For other distributions, please check if this package is available in your package manager's repository.
 
 # Usage
 
-If you've installed it through your package manager, then it should already contain a launcher for it. Otherwise, run the `dl-desktop` binary.
+If you've installed it through your package manager, it should automatically add a launcher for the app. Otherwise, you can run the `dl-desktop` binary manually.
 
 # Building from source (Linux)
 
 You will need to install [npm](https://www.npmjs.com/), the Node.js package manager.
 
-In the main directory of this repository run the following:
+In the main directory of this repository, run the following commands:
+
 ```bash
 npm install
 npm run build
 ```
 
-
 # Building from source (Windows)
 
-You will need to install [Node.js](https://nodejs.org/en/download/current/) which includes npm.
+You will need to install [Node.js](https://nodejs.org/en/download/current/), which includes npm.
 
-Afterwards run the following in the main directory depending on your current system:
+Then, depending on your system, run the following commands in the main directory:
 
-If you are building on Windows:
+For Windows:
 ```powershell
 npm install
 ./node_modules/.bin/electron-builder --win
 ```
-If you are building on Linux:
+
+For Linux (to build for Windows):
 ```bash
 npm install
 sudo ./node_modules/.bin/electron-builder --win
 ```
 
 # Credits
- - Duolingo itself, for being an awesome language learning platform
- - [creepertron95](https://github.com/creepertron95) for the [icon](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/blob/6e4fea69f884e2e874e872b87e49892a246be65d/Papirus/48x48/apps/duolingo.svg)
- - Our [contributors](https://github.com/hmlendea/dl-desktop/graphs/contributors)!
+- Duolingo, for providing an awesome language learning platform.
+- [creepertron95](https://github.com/creepertron95) for the [icon](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme/blob/6e4fea69f884e2e874e872b87e49892a246be65d/Papirus/48x48/apps/duolingo.svg).
+- All our [contributors](https://github.com/hmlendea/dl-desktop/graphs/contributors)!
 
-_The name Duolingo, and the Duolingo logo, are copyrights of Duolingo_
+_The name Duolingo and the Duolingo logo are copyrights of Duolingo._


### PR DESCRIPTION
…p-git`

- Updated the README to recommend `duolingo-desktop-bin` from the AUR instead of the outdated `duolingo-desktop-git` package, which hasn't been updated since 2020. This change provides better guidance for Arch Linux users seeking an up-to-date installation.

- Clarified support status for different package sources: the FlatHub version is now marked as officially supported, while AUR and Snap versions are community-maintained.

- Minor wording and formatting improvements across the README for consistency and readability.

- Added backticks around package names for better readability and linked to relevant AUR package.